### PR TITLE
Increase php memory to 256M with custom config file.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,3 +13,6 @@ RUN phpcs --config-set installed_paths ~/.composer/vendor/drupal/coder/coder_sni
 # Add the kontena CLI.
 RUN wget -O /tmp/kontena.deb https://gh-releases.kontena.io/kontena/kontena/deb/latest
 RUN sudo dpkg -i /tmp/kontena.deb
+
+# Add custom php config. Increase memory to 256M
+COPY conf/php/memory.ini /usr/local/etc/php/conf.d/memory.ini

--- a/conf/php/memory.ini
+++ b/conf/php/memory.ini
@@ -1,0 +1,1 @@
+memory_limit = 256M


### PR DESCRIPTION
This should fix the issues with drush crashing in tests due to memory issues.

Increase PHP memory from 128M to 256M